### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 /[Bb]uild/
 /[Bb]uilds/
 /[Ll]ogs/
+/[Uu]ser[Ss]ettings/
+
+# MemoryCaptures can get excessive in size.
+# They also could contain extremely sensitive data
 /[Mm]emoryCaptures/
 
 # Asset meta data should only be ignored when the corresponding asset is also ignored
@@ -58,6 +62,12 @@ sysinfo.txt
 # Crashlytics generated file
 crashlytics-build.properties
 
+# Packed Addressables
+/[Aa]ssets/[Aa]ddressable[Aa]ssets[Dd]ata/*/*.bin*
+
+# Temporary auto-generated Android Assets
+/[Aa]ssets/[Ss]treamingAssets/aa.meta
+/[Aa]ssets/[Ss]treamingAssets/aa/*
 
 # Ignore blend1 files
 *.blend1*


### PR DESCRIPTION
Onze huidige gitignore is niet up to date met de huidige go-to gitignore van unity, hierdoor is `UserSettings/EditorUserSettings.assets` in onze tracking beland en wordt als veranderd gemarkeerd. Dit moet voorkomen dat dit gebeurt met andere files.

We moeten binnekort nog effe `UserSettings/EditorUserSettings.assets` eruit gooien.